### PR TITLE
Fixing Adabot Description Documentation

### DIFF
--- a/adabot-gazebo-Package.md
+++ b/adabot-gazebo-Package.md
@@ -46,6 +46,8 @@ rocky3          ...
 step            ...
 ```
 
+__NOTE:__ Any world files created must be kept in the `adabot_gazebo` folder and use the naming schema, `adabot.<world_name>.world`.
+
 ### File Structure
 ```
 adabot_gazebo
@@ -54,11 +56,8 @@ adabot_gazebo
 ├── launch
 |   └── adabot.world.launch
 └── worlds
-    ├── adabot.empty.xacro
+    ├── adabot.empty.world
     ├── ...
     └── worldModels
       └── ...
 ```
-#### 'worlds' folder
-
-This folder contains different worlds that adabot can be launched within. They use the name schema `adabot.<world_name>.xacro`.

--- a/adabot-gazebo-Package.md
+++ b/adabot-gazebo-Package.md
@@ -7,19 +7,7 @@ Gazebo allows a robot described in a .xacro file to be launched in a dynamic env
 
 Command to launch adabot in a gazebo world:
 
-`roslaunch adabot_gazebo adabot.<world_name>.launch`
-
-#### Gazebo Worlds
-Replace `<world_name>` in the above command with one of the following worlds to launch adabot in. [This folder](https://github.com/anthony-jclark/adabot/tree/master/adabot_gazebo/worlds) contains the different gazebo worlds.
-```
-WORLD NAME      DESCRIPTION
-empty           An empty gazebo world
-fast-rocky3     ...
-fast-step       ...
-rocky           ...
-rocky3          ...
-step            ...
-```
+`roslaunch adabot_gazebo adabot.world.launch`
 
 #### Launching with parameters
 Multiple parameters can be passed in to adjust different dimensions of adabot
@@ -28,7 +16,7 @@ Multiple parameters can be passed in to adjust different dimensions of adabot
 
 Example:
 
-`roslaunch adabot_gazebo adabot.world.launch ch_width:=.75 wg_per_wheel:=3`
+`roslaunch adabot_gazebo adabot.world.launch ch_width:=.75 wg_per_wheel:=3 world:=rocky`
 
 Parameter List
 ```
@@ -39,11 +27,24 @@ wh_radius       radius for each wheel                     0.020
 ax_radius       radius of the axle (limits extnesion)     0.008
 wg_per_wheel    number of wegs on each of wheels          5
 scale           scaling factor for the entire device      4
+world           gazebo world to launch adabot in          rocky
 ```
 
 Parameters are defined in the `adabot.model.launch` file [here](https://github.com/anthony-jclark/adabot/blob/master/adabot_description/launch/adabot.model.launch#L23-L35). Each parameter has a default value that will be overridden by any that are passed in through the command line (as shown above).
 
 These values are then passed [here](https://github.com/anthony-jclark/adabot/blob/master/adabot_description/urdf/adabot.parameters.xacro#L8-L19) to the `adabot.parameters.xacro` file. The xacro file also has defaults that will be overridden by any value passed in from the `adabot.model.launch` file above.
+
+#### Gazebo Worlds
+Pass in the `world` parameter to the launch file (as described above) to launch adabot in one of the following worlds. [This folder](https://github.com/anthony-jclark/adabot/tree/master/adabot_gazebo/worlds) contains the different gazebo worlds available.
+```
+WORLD NAME      DESCRIPTION
+empty           (Default) An empty gazebo world
+fast-rocky3     ...
+fast-step       ...
+rocky           ...
+rocky3          ...
+step            ...
+```
 
 ### File Structure
 ```


### PR DESCRIPTION
Fixed the command/description for specifying a gazebo world

__NOTICE:__
Currently you need to specify the gazebo world this way: `world:=$(rospack find adabot_gazebo)/worlds/adabot.step.world`
I am working on changing it to be specified this way: `world:=step`
I have updated the documentation to reflect this future change.
Down the road I can add documentation on needing to follow the naming parameter of "adabot.<world_name>.world" in another page so that this simpler command will work for any worlds created down the road.